### PR TITLE
Make PhysicalAddress.GetHashCode thread-safe.

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -9,7 +9,6 @@ namespace System.Net.NetworkInformation
     public class PhysicalAddress
     {
         private readonly byte[] _address = null;
-        private bool _hashNotComputed = true;
         private int _hash = 0;
 
         public static readonly PhysicalAddress None = new PhysicalAddress(Array.Empty<byte>());
@@ -21,17 +20,16 @@ namespace System.Net.NetworkInformation
 
         public override int GetHashCode()
         {
-            if (_hashNotComputed)
+            if (_hash != 0)
             {
-                _hashNotComputed = false;
-                _hash = 0;
+                var hash = 0;
 
                 int i;
                 int size = _address.Length & ~3;
 
                 for (i = 0; i < size; i += 4)
                 {
-                    _hash ^= (int)_address[i]
+                    hash ^= (int)_address[i]
                             | ((int)_address[i + 1] << 8)
                             | ((int)_address[i + 2] << 16)
                             | ((int)_address[i + 3] << 24);
@@ -48,8 +46,15 @@ namespace System.Net.NetworkInformation
                         shift += 8;
                     }
 
-                    _hash ^= remnant;
+                    hash ^= remnant;
                 }
+
+                if (hash == 0)
+                {
+                    hash = 1;
+                }
+                
+                _hash = hash;
             }
 
             return _hash;


### PR DESCRIPTION
PhysicalAddress.GetHashCode is not thread-safe and this is not obvious.